### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that captures screenshots of web pages using Puppeteer. This server allows AI agents to visually verify web applications and see their progress when generating web apps.
 
+<a href="https://glama.ai/mcp/servers/@ananddtyagi/webpage-screenshot-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ananddtyagi/webpage-screenshot-mcp/badge" alt="Webpage Screenshot Server MCP server" />
+</a>
+
 ![Screen Recording May 27 2025 (2)](https://github.com/user-attachments/assets/9f186ec4-5a5c-449b-9a30-a5ec0cdba695)
 
 


### PR DESCRIPTION
This PR adds a badge for the [Webpage Screenshot MCP Server](https://glama.ai/mcp/servers/@ananddtyagi/webpage-screenshot-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ananddtyagi/webpage-screenshot-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ananddtyagi/webpage-screenshot-mcp/badge" alt="Webpage Screenshot Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.